### PR TITLE
add concurrency & parallelism

### DIFF
--- a/helm/app-updater-app/templates/cronjob.yaml
+++ b/helm/app-updater-app/templates/cronjob.yaml
@@ -6,9 +6,11 @@ metadata:
     app:  {{ template "app-updater.fullname" . }}
 spec:
   schedule: {{ .Values.schedule | quote }}
+  concurrencyPolicy: Replace
   jobTemplate:
     spec:
       backoffLimit: 3
+      parallelism: 1
       ttlSecondsAfterFinished: 600
       template:
         spec:


### PR DESCRIPTION
Adds 

- `concurrencyPolicy: Replace`: "Replace": cancels currently running job and replaces it with a new one
- `parallelism: 1`: Specifies the maximum desired number of pods the job should run at any given time.